### PR TITLE
ocp helm chart final updates for Fusion 552

### DIFF
--- a/5.5.2/fusion/charts/admin-ui/templates/deployment.yaml
+++ b/5.5.2/fusion/charts/admin-ui/templates/deployment.yaml
@@ -67,7 +67,6 @@ spec:
       - name: admin-ui
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         lifecycle:
           preStop:
             exec:

--- a/5.5.2/fusion/charts/admin-ui/values.yaml
+++ b/5.5.2/fusion/charts/admin-ui/values.yaml
@@ -8,10 +8,6 @@ autoscaling:
       targetAverageUtilization: 70
     type: Resource
   minReplicas: 1
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 deploymentStrategy:
   rollingUpdate:
     maxSurge: 25%

--- a/5.5.2/fusion/charts/api-gateway/templates/deployment.yaml
+++ b/5.5.2/fusion/charts/api-gateway/templates/deployment.yaml
@@ -105,12 +105,7 @@ spec:
       - name: api-gateway
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          allowPrivilegeEscalation: false
-          privileged: false
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
+
         args:
           - "--spring.profiles.active={{ include "fusion.api-gateway.springProfs" . }}{{- if $tlsEnabled }},tls{{- end }}{{- if $jsonOutput }},logjson{{- end }}{{- if $logstashHost }},logstash{{- end }}{{- if $logPulsar }},logpulsar{{- end }}"
           - "--spring.cloud.kubernetes.secrets.paths=/etc/secrets"

--- a/5.5.2/fusion/charts/api-gateway/templates/deployment.yaml
+++ b/5.5.2/fusion/charts/api-gateway/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
             - name: API_GATEWAY_JKS_BASE64
               valueFrom:
                 secretKeyRef:
-                  name:  dataes-api-gateway-jks
+                  name:  "{{ .Release.Name }}-api-gateway-jks"
                   key: api-gateway.jks
           volumeMounts:
             - name: jks

--- a/5.5.2/fusion/charts/api-gateway/values.yaml
+++ b/5.5.2/fusion/charts/api-gateway/values.yaml
@@ -13,10 +13,6 @@ config:
   resilience4j: ""
   security: ""
   springSecurity: ""
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 datadog:
   enabled: false
   port: 8126

--- a/5.5.2/fusion/charts/auth-ui/templates/deployment.yaml
+++ b/5.5.2/fusion/charts/auth-ui/templates/deployment.yaml
@@ -61,20 +61,13 @@ spec:
       {{ end }}
 {{- if $tlsEnabled }}
       initContainers:
-{{ $params := dict "tlsServiceName" ( include "fusion.auth-ui.serviceName" . ) "Release" $.Release "global" $.Values.global "tls" $.Values.tls  "keytoolUtils" $.Values.keytoolUtils "securityContext" $.Values.securityContext }}
+{{ $params := dict "tlsServiceName" ( include "fusion.auth-ui.serviceName" . ) "Release" $.Release "global" $.Values.global "tls" $.Values.tls  "keytoolUtils" $.Values.keytoolUtils }}
 {{ include "fusion.tls.init-container-v2" $params | indent 8 }}
 {{- end }}
       containers:
       - name: auth-ui
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          allowPrivilegeEscalation: false
-          privileged: false
-          runAsUser: {{ .Values.securityContext.runAsUser }}
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         # args:
         #   -
         ports:

--- a/5.5.2/fusion/charts/auth-ui/values.yaml
+++ b/5.5.2/fusion/charts/auth-ui/values.yaml
@@ -8,10 +8,6 @@ autoscaling:
       targetAverageUtilization: 70
     type: Resource
   minReplicas: 1
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 deploymentStrategy:
   rollingUpdate:
     maxSurge: 25%

--- a/5.5.2/fusion/charts/classic-rest-service/templates/statefulset.yaml
+++ b/5.5.2/fusion/charts/classic-rest-service/templates/statefulset.yaml
@@ -54,7 +54,7 @@ spec:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       initContainers:
 {{- if $tlsEnabled -}}
-{{ $params := dict "tlsServiceName" ( include "fusion.classic-rest-service.serviceName" . ) "Release" .Release "global" .Values.global "tls" .Values.tls  "keytoolUtils" .Values.keytoolUtils "securityContext" $.Values.securityContext }}
+{{ $params := dict "tlsServiceName" ( include "fusion.classic-rest-service.serviceName" . ) "Release" .Release "global" .Values.global "tls" .Values.tls  "keytoolUtils" .Values.keytoolUtils }}
 {{ include "fusion.tls.init-container-v2" $params | indent 8 }}
 {{- end }}
         {{- include "fusion.initContainers.checkZk-v2" . | nindent 8 }}
@@ -121,7 +121,6 @@ spec:
       - name: classic-rest-service
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         env:
           - name: "COMPONENT"
             value: "connectors-classic"

--- a/5.5.2/fusion/charts/classic-rest-service/values.yaml
+++ b/5.5.2/fusion/charts/classic-rest-service/values.yaml
@@ -21,7 +21,7 @@ image:
   repository: lucidworks
   tag: latest
 javaToolOptions: -XX:+ExitOnOutOfMemoryError -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=75.0
-  -Xss256k -Dhttp.maxConnections=1000
+  -Xss256k
 keytoolUtils:
   image:
     imagePullPolicy: IfNotPresent

--- a/5.5.2/fusion/charts/classic-rest-service/values.yaml
+++ b/5.5.2/fusion/charts/classic-rest-service/values.yaml
@@ -3,10 +3,6 @@ affinity: {}
 annotations: {}
 bootstrapEnabled: true
 component: classic-rest-service
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 deploymentStrategy:
   rollingUpdate:
     maxSurge: 25%
@@ -68,10 +64,6 @@ readinessProbe:
   successThreshold: 1
   timeoutSeconds: 2
 replicaCount: 1
-securityContext:
-  fsGroup: 8764
-  runAsNonRoot: true
-  runAsUser: 8764
 serviceName: connectors-classic
 springProfiles: k8s,jwt
 tls:

--- a/5.5.2/fusion/charts/connector-plugin/templates/configmap.yml
+++ b/5.5.2/fusion/charts/connector-plugin/templates/configmap.yml
@@ -107,7 +107,7 @@ data:
             {{- toYaml .Values.image.imagePullSecrets | nindent 12 }}
           initContainers:
     {{- if $tlsEnabled -}}
-    {{ $params := dict "tlsServiceName" ( include "fusion.connector-plugin.serviceName" . ) "Release" .Release "global" .Values.global "tls" .Values.tls  "keytoolUtils" .Values.keytoolUtils "securityContext" $.Values.securityContext }}
+    {{ $params := dict "tlsServiceName" ( include "fusion.connector-plugin.serviceName" . ) "Release" .Release "global" .Values.global "tls" .Values.tls  "keytoolUtils" .Values.keytoolUtils }}
     {{ include "fusion.tls.init-container-v2" $params | nindent 12 }}
     {{- end }}
     {{- if $importTrustedCertsEnabled }}
@@ -214,7 +214,7 @@ data:
                 - name: SPRING_PROFILES_ACTIVE
                   value: "{{ .Values.springProfiles }}{{- if $tlsEnabled }},tls{{- end }}{{- if $jsonOutput }},logjson{{- end }}{{- if $logstashHost }},logstash{{- end }}{{- if $logPulsar }},logpulsar{{- end }}"
                 - name: JAVA_TOOL_OPTIONS
-                  value: "
+                  value: "-Dlogging.config=classpath:logback-kube.xml 
     {{- if ( and $importTrustedCertsEnabled ( not $tlsEnabled )) }} -Djavax.net.ssl.trustStore=/etc/ssl/truststore/truststore.jks -Djavax.net.ssl.trustStorePassword=changeit -Djavax.net.ssl.trustStoreType=PKCS12{{- end }}
     {{- if $tlsEnabled }} -Djavax.net.ssl.trustStore=/etc/ssl/keystores/truststore.jks -Djavax.net.ssl.trustStorePassword={{ .Values.tls.keystorePassword }} -Djavax.net.ssl.trustStoreType=PKCS12 -Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true -Dzookeeper.ssl.keyStore.location=/etc/ssl/keystores/keystore.jks -Dzookeeper.ssl.trustStore.location=/etc/ssl/keystores/truststore.jks -Dzookeeper.ssl.keyStore.password={{ .Values.tls.keystorePassword }} -Dzookeeper.ssl.trustStore.password={{ .Values.tls.keystorePassword }}{{- end }} -Dspring.cloud.kubernetes.secrets.paths=/etc/secrets {{ .Values.javaToolOptions }}"
                 {{ if $logstashHost }}

--- a/5.5.2/fusion/charts/connector-plugin/values.yaml
+++ b/5.5.2/fusion/charts/connector-plugin/values.yaml
@@ -95,10 +95,6 @@ readinessProbe:
   successThreshold: 1
   timeoutSeconds: 10
 replicaCount: 0
-securityContext:
-  fsGroup: 8764
-  runAsNonRoot: true
-  runAsUser: 8764
 serviceName: connector-plugin
 springProfiles: k8s,jwt
 tls:

--- a/5.5.2/fusion/charts/connector-plugin/values.yaml
+++ b/5.5.2/fusion/charts/connector-plugin/values.yaml
@@ -42,7 +42,7 @@ image:
   pullPolicy: IfNotPresent
   repository: lucidworks
   tag: latest
-javaToolOptions: -XX:+ExitOnOutOfMemoryError -XX:MaxRAMPercentage=40.0 -Xss256k -Dhttp.maxConnections=1000
+javaToolOptions: -XX:+ExitOnOutOfMemoryError -XX:MaxRAMPercentage=40.0 -Xss256k
   -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps -XX:+StartAttachListener
   -Djdk.attach.allowAttachSelf=true
 keytoolUtils:

--- a/5.5.2/fusion/charts/connectors-backend/templates/deployment.yml
+++ b/5.5.2/fusion/charts/connectors-backend/templates/deployment.yml
@@ -102,7 +102,7 @@ spec:
             - name: SPRING_PROFILES_ACTIVE
               value: "{{ .Values.springProfiles }}{{- if $tlsEnabled }},tls{{- end }}{{- if $jsonOutput }},logjson{{- end }}{{- if $logstashHost }},logstash{{- end }}{{- if $logPulsar }},logpulsar{{- end }}"
             - name: JAVA_TOOL_OPTIONS
-              value: "-Dspring.cloud.kubernetes.secrets.paths=/etc/secrets {{ .Values.javaToolOptions }}
+              value: "-Dkubernetes.connection.timeout=240000 -Dkubernetes.request.timeout=240000 -Dlogging.config=/config-map/logback-kube.xml -Dspring.cloud.kubernetes.secrets.paths=/etc/secrets {{ .Values.javaToolOptions }}
 {{- if $tlsEnabled }} -Djavax.net.ssl.trustStore=/etc/ssl/keystores/truststore.jks -Djavax.net.ssl.trustStorePassword={{ .Values.tls.keystorePassword }} -Djavax.net.ssl.trustStoreType=PKCS12 -Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true -Dzookeeper.ssl.keyStore.location=/etc/ssl/keystores/keystore.jks -Dzookeeper.ssl.trustStore.location=/etc/ssl/keystores/truststore.jks -Dzookeeper.ssl.keyStore.password={{ .Values.tls.keystorePassword }} -Dzookeeper.ssl.trustStore.password={{ .Values.tls.keystorePassword }}{{- end -}}
 "
             {{ if $logstashHost }}

--- a/5.5.2/fusion/charts/connectors-backend/templates/deployment.yml
+++ b/5.5.2/fusion/charts/connectors-backend/templates/deployment.yml
@@ -54,7 +54,7 @@ spec:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       initContainers:
 {{- if $tlsEnabled -}}
-{{ $params := dict "tlsServiceName" ( include "fusion.connectors-backend.serviceName" . ) "Release" .Release "global" .Values.global "tls" .Values.tls  "keytoolUtils" .Values.keytoolUtils "securityContext" $.Values.securityContext }}
+{{ $params := dict "tlsServiceName" ( include "fusion.connectors-backend.serviceName" . ) "Release" .Release "global" .Values.global "tls" .Values.tls  "keytoolUtils" .Values.keytoolUtils }}
 {{ include "fusion.tls.init-container-v2" $params | indent 8 }}
 {{- end }}
         {{- include "fusion.initContainers.checkZk-v2" . | nindent 8 }}
@@ -65,12 +65,6 @@ spec:
         - name: connectors-backend
           image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          securityContext:
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
-            privileged: false
-{{- .Values.containersSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
             - name: application-config-k8s
               mountPath: "app/config"
@@ -102,7 +96,7 @@ spec:
             - name: SPRING_PROFILES_ACTIVE
               value: "{{ .Values.springProfiles }}{{- if $tlsEnabled }},tls{{- end }}{{- if $jsonOutput }},logjson{{- end }}{{- if $logstashHost }},logstash{{- end }}{{- if $logPulsar }},logpulsar{{- end }}"
             - name: JAVA_TOOL_OPTIONS
-              value: "-Dkubernetes.connection.timeout=240000 -Dkubernetes.request.timeout=240000 -Dlogging.config=/config-map/logback-kube.xml -Dspring.cloud.kubernetes.secrets.paths=/etc/secrets {{ .Values.javaToolOptions }}
+              value: "-Dkubernetes.connection.timeout=240000 -Dkubernetes.request.timeout=240000 -Dlogging.config=classpath:logback-kube.xml -Dspring.cloud.kubernetes.secrets.paths=/etc/secrets {{ .Values.javaToolOptions }}
 {{- if $tlsEnabled }} -Djavax.net.ssl.trustStore=/etc/ssl/keystores/truststore.jks -Djavax.net.ssl.trustStorePassword={{ .Values.tls.keystorePassword }} -Djavax.net.ssl.trustStoreType=PKCS12 -Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty -Dzookeeper.client.secure=true -Dzookeeper.ssl.keyStore.location=/etc/ssl/keystores/keystore.jks -Dzookeeper.ssl.trustStore.location=/etc/ssl/keystores/truststore.jks -Dzookeeper.ssl.keyStore.password={{ .Values.tls.keystorePassword }} -Dzookeeper.ssl.trustStore.password={{ .Values.tls.keystorePassword }}{{- end -}}
 "
             {{ if $logstashHost }}

--- a/5.5.2/fusion/charts/connectors-backend/values.yaml
+++ b/5.5.2/fusion/charts/connectors-backend/values.yaml
@@ -10,10 +10,6 @@ autoscaling:
     type: Resource
   minReplicas: 1
 component: connectors-backend
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 deploymentStrategy:
   rollingUpdate:
     maxSurge: 25%
@@ -91,10 +87,6 @@ readinessProbe:
   successThreshold: 1
   timeoutSeconds: 10
 replicaCount: 1
-securityContext:
-  fsGroup: 8764
-  runAsNonRoot: true
-  runAsUser: 8764
 serviceName: connectors-backend
 springProfiles: k8s,jwt
 tls:

--- a/5.5.2/fusion/charts/connectors-backend/values.yaml
+++ b/5.5.2/fusion/charts/connectors-backend/values.yaml
@@ -28,7 +28,7 @@ image:
   repository: lucidworks
   tag: latest
 javaToolOptions: -XX:+ExitOnOutOfMemoryError -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=75.0
-  -Xss256k -Dhttp.maxConnections=1000 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps
+  -Xss256k -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps
   -XX:+StartAttachListener -Djdk.attach.allowAttachSelf=true
 keytoolUtils:
   image:

--- a/5.5.2/fusion/charts/connectors/templates/deployment.yml
+++ b/5.5.2/fusion/charts/connectors/templates/deployment.yml
@@ -54,7 +54,7 @@ spec:
 {{ toYaml .Values.image.imagePullSecrets | indent 8 }}
       initContainers:
 {{- if $tlsEnabled -}}
-{{ $params := dict "tlsServiceName" ( include "fusion.connectors.serviceName" . ) "Release" .Release "global" .Values.global "tls" .Values.tls  "keytoolUtils" .Values.keytoolUtils "securityContext" $.Values.securityContext }}
+{{ $params := dict "tlsServiceName" ( include "fusion.connectors.serviceName" . ) "Release" .Release "global" .Values.global "tls" .Values.tls  "keytoolUtils" .Values.keytoolUtils }}
 {{ include "fusion.tls.init-container-v2" $params | indent 8 }}
 {{- end }}
         {{- include "fusion.initContainers.checkZk-v2" . | nindent 8 }}
@@ -63,13 +63,6 @@ spec:
         - name: connectors
           image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          securityContext:
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
-            privileged: false
-            capabilities:
-              drop: ["NET_RAW"]
           volumeMounts:
             - name: application-config-k8s
               mountPath: "app/config"

--- a/5.5.2/fusion/charts/connectors/values.yaml
+++ b/5.5.2/fusion/charts/connectors/values.yaml
@@ -29,7 +29,7 @@ image:
   repository: lucidworks
   tag: latest
 javaToolOptions: -XX:+ExitOnOutOfMemoryError -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=75.0
-  -Xss256k -Dhttp.maxConnections=1000
+  -Xss256k
 keytoolUtils:
   image:
     imagePullPolicy: IfNotPresent

--- a/5.5.2/fusion/charts/connectors/values.yaml
+++ b/5.5.2/fusion/charts/connectors/values.yaml
@@ -11,10 +11,6 @@ autoscaling:
     type: Resource
   minReplicas: 1
 component: connectors
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 deploymentStrategy:
   rollingUpdate:
     maxSurge: 25%
@@ -80,10 +76,6 @@ readinessProbe:
   successThreshold: 1
   timeoutSeconds: 2
 replicaCount: 1
-securityContext:
-  fsGroup: 8764
-  runAsNonRoot: true
-  runAsUser: 8764
 serviceName: connectors
 springProfiles: k8s,jwt
 tls:

--- a/5.5.2/fusion/charts/devops-ui/templates/deployment.yaml
+++ b/5.5.2/fusion/charts/devops-ui/templates/deployment.yaml
@@ -67,7 +67,6 @@ spec:
       - name: devops-ui
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         lifecycle:
           preStop:
             exec:

--- a/5.5.2/fusion/charts/fusion-admin/templates/deployment.yaml
+++ b/5.5.2/fusion/charts/fusion-admin/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
         - name: {{ .Values.name }}
           image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
           imagePullPolicy: "{{ .Values.image.pullPolicy }}"
-{{- .Values.containersSecurityContext | toYaml | nindent 12 }}
+
           env:
             - name: "COMPONENT"
               value: "fusion-admin"

--- a/5.5.2/fusion/charts/fusion-admin/values.yaml
+++ b/5.5.2/fusion/charts/fusion-admin/values.yaml
@@ -7,10 +7,6 @@ autoscaling:
       targetAverageUtilization: 70
     type: Resource
   minReplicas: 1
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 fusion-common-utils:
   global: {}
 image:

--- a/5.5.2/fusion/charts/fusion-admin/values.yaml
+++ b/5.5.2/fusion/charts/fusion-admin/values.yaml
@@ -26,7 +26,7 @@ ingress:
   host: ingress.example.com
   tls:
     enabled: false
-jvmOptions: -XX:+ExitOnOutOfMemoryError -Xms1g -Xmx2g -Xss256k -Dhttp.maxConnections=1000
+jvmOptions: -XX:+ExitOnOutOfMemoryError -Xms1g -Xmx2g -Xss256k
   -XX:PermSize=256m -XX:MaxPermSize=512m
 keytoolUtils:
   image:

--- a/5.5.2/fusion/charts/fusion-data-augmentation/templates/configmap.yml
+++ b/5.5.2/fusion/charts/fusion-data-augmentation/templates/configmap.yml
@@ -186,9 +186,6 @@ data:
         container:
           image: busybox
           imagePullPolicy: "{{`{{workflow.parameters.image_pull_policy}}`}}"
-          securityContext:
-            capabilities:
-                drop: ["NET_RAW"]
           resources:
             {{ .Values.resources.default  | toYaml | nindent 12  }}
 
@@ -212,9 +209,6 @@ data:
           # Using fusion-data-augmentation image to make sure the right user is used
           image: "{{`{{workflow.parameters.docker_repo}}`}}/fusion-data-augmentation:{{`{{workflow.parameters.data_augmentation_tag}}`}}"
           imagePullPolicy: "{{`{{workflow.parameters.image_pull_policy}}`}}"
-          securityContext:
-            capabilities:
-                drop: ["NET_RAW"]
           resources:
             {{ .Values.resources.default  | toYaml | nindent 12 }}
 
@@ -239,9 +233,6 @@ data:
           # Using fusion-data-augmentation image to make sure the right user is used
           image: "{{`{{workflow.parameters.docker_repo}}`}}/fusion-data-augmentation:{{`{{workflow.parameters.data_augmentation_tag}}`}}"
           imagePullPolicy: "{{`{{workflow.parameters.image_pull_policy}}`}}"
-          securityContext:
-            capabilities:
-                drop: ["NET_RAW"]
           resources:
             {{ .Values.resources.default  | toYaml | nindent 12  }}
 
@@ -267,9 +258,6 @@ data:
           # Using fusion-data-augmentation image to make sure the right user is used
           image: "{{`{{workflow.parameters.docker_repo}}`}}/fusion-data-augmentation:{{`{{workflow.parameters.data_augmentation_tag}}`}}"
           imagePullPolicy: "{{`{{workflow.parameters.image_pull_policy}}`}}"
-          securityContext:
-            capabilities:
-                drop: ["NET_RAW"]
           resources:
             {{ .Values.resources.default  | toYaml | nindent 12  }}
 
@@ -295,9 +283,6 @@ data:
           # Using fusion-data-augmentation image to make sure the right user is used
           image: "{{`{{workflow.parameters.docker_repo}}`}}/fusion-data-augmentation:{{`{{workflow.parameters.data_augmentation_tag}}`}}"
           imagePullPolicy: "{{`{{workflow.parameters.image_pull_policy}}`}}"
-          securityContext:
-            capabilities:
-                drop: ["NET_RAW"]
           resources:
             {{ .Values.resources.default  | toYaml | nindent 12  }}
 
@@ -332,9 +317,6 @@ data:
         container:
           image: "{{`{{workflow.parameters.docker_repo}}`}}/spark-solr-etl:{{`{{workflow.parameters.spark_solr_tag}}`}}"
           imagePullPolicy: "{{`{{workflow.parameters.image_pull_policy}}`}}"
-          securityContext:
-            capabilities:
-                drop: ["NET_RAW"]
           resources:
             {{ .Values.resources.etl | default .Values.resources.default | toYaml | nindent 12  }}
 
@@ -431,9 +413,6 @@ data:
         container:
           image: "{{`{{workflow.parameters.docker_repo}}`}}/fusion-workflow-utilities:{{`{{workflow.parameters.utilities_tag}}`}}"
           imagePullPolicy: "{{`{{workflow.parameters.image_pull_policy}}`}}"
-          securityContext:
-            capabilities:
-                drop: ["NET_RAW"]
           resources:
             {{ .Values.resources.default  | toYaml | nindent 12 }}
           command: [ tini, --, python, transfer_blobs.py ]
@@ -500,9 +479,6 @@ data:
         container:
           image: "{{`{{workflow.parameters.docker_repo}}`}}/fusion-workflow-utilities:{{`{{workflow.parameters.utilities_tag}}`}}"
           imagePullPolicy: "{{`{{workflow.parameters.image_pull_policy}}`}}"
-          securityContext:
-            capabilities:
-                drop: ["NET_RAW"]
           resources:
             {{ .Values.resources.default  | toYaml | nindent 12 }}
           command: [ tini, --, python, transfer_blobs.py ]
@@ -546,9 +522,6 @@ data:
         container:
           image: "{{`{{workflow.parameters.docker_repo}}`}}/fusion-data-augmentation:{{`{{workflow.parameters.data_augmentation_tag}}`}}"
           imagePullPolicy: "{{`{{workflow.parameters.image_pull_policy}}`}}"
-          securityContext:
-            capabilities:
-                drop: ["NET_RAW"]
           resources:
             {{ .Values.resources.augment | default .Values.resources.default | toYaml | nindent 12  }}
           env:
@@ -583,9 +556,6 @@ data:
         container:
           image: "{{`{{workflow.parameters.docker_repo}}`}}/spark-solr-etl:{{`{{workflow.parameters.spark_solr_tag}}`}}"
           imagePullPolicy: "{{`{{workflow.parameters.image_pull_policy}}`}}"
-          securityContext:
-            capabilities:
-                drop: ["NET_RAW"]
           resources:
             {{ .Values.resources.etl | default .Values.resources.default | toYaml | nindent 12  }}
           args: ["push",
@@ -618,9 +588,6 @@ data:
         container:
           image: "{{`{{workflow.parameters.docker_repo}}`}}/spark-solr-etl:{{`{{workflow.parameters.spark_solr_tag}}`}}"
           imagePullPolicy: "{{`{{workflow.parameters.image_pull_policy}}`}}"
-          securityContext:
-            capabilities:
-                drop: ["NET_RAW"]
           resources:
             {{ .Values.resources.etl | default .Values.resources.default | toYaml | nindent 12 }}
 

--- a/5.5.2/fusion/charts/fusion-indexing/templates/_helpers_.tpl
+++ b/5.5.2/fusion/charts/fusion-indexing/templates/_helpers_.tpl
@@ -147,12 +147,6 @@ app.kubernetes.io/part-of: "fusion"
 - name: check-indexing
   image: {{ .Values.image.repository }}/check-fusion-dependency:v1.3.0
   imagePullPolicy: IfNotPresent
-  securityContext:
-    readOnlyRootFilesystem: true
-    runAsNonRoot: true
-    allowPrivilegeEscalation: false
-    privileged: false
-    runAsUser: {{ .Values.securityContext.runAsUser }}
   resources:
     requests:
       cpu: 200m

--- a/5.5.2/fusion/charts/fusion-indexing/templates/deployment.yaml
+++ b/5.5.2/fusion/charts/fusion-indexing/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
     {{ end }}
       initContainers:
 {{- if $tlsEnabled -}}
-{{ $params := dict "tlsServiceName" ( include "fusion.fusion-indexing.serviceName" . ) "Release" $.Release "global" $.Values.global "tls" $.Values.tls  "keytoolUtils" $.Values.keytoolUtils "securityContext" $.Values.securityContext }}
+{{ $params := dict "tlsServiceName" ( include "fusion.fusion-indexing.serviceName" . ) "Release" $.Release "global" $.Values.global "tls" $.Values.tls  "keytoolUtils" $.Values.keytoolUtils }}
 {{ include "fusion.tls.init-container-v2" $params | indent 8 }}
 {{- end }}
 {{- include "fusion.initContainers.checkZk-v2" . | nindent 8 }}
@@ -67,7 +67,6 @@ spec:
       - name: fusion-indexing
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         args:
           - "--spring.profiles.active={{ include "fusion.fusion-indexing.springProfs" . }}{{- if $tlsEnabled }},tls{{- end }}{{- if $jsonOutput }},logjson{{- end }}{{- if $logstashHost }},logstash{{- end }}{{- if $logPulsar }},logpulsar{{- end }}"
           - "--spring.cloud.kubernetes.config.name={{ include "fusion.fusion-indexing.fullname" . }}"

--- a/5.5.2/fusion/charts/fusion-indexing/values.yaml
+++ b/5.5.2/fusion/charts/fusion-indexing/values.yaml
@@ -9,10 +9,6 @@ autoscaling:
       targetAverageUtilization: 70
     type: Resource
   minReplicas: 1
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 datadog:
   enabled: false
   port: 8126
@@ -73,10 +69,6 @@ readinessProbe:
   periodSeconds: 10
 replicaCount: 1
 resources: {}
-securityContext:
-  fsGroup: 8764
-  runAsNonRoot: true
-  runAsUser: 8764
 serverStopTimeout: 5000
 service:
   annotations: {}

--- a/5.5.2/fusion/charts/fusion-indexing/values.yaml
+++ b/5.5.2/fusion/charts/fusion-indexing/values.yaml
@@ -29,7 +29,7 @@ image:
   name: fusion-indexing
   repository: lucidworks
   tag: latest
-javaToolOptions: -XX:+ExitOnOutOfMemoryError -Xms512m -Xmx1g -Xss256k -Dhttp.maxConnections=1000
+javaToolOptions: -XX:+ExitOnOutOfMemoryError -Xms512m -Xmx1g -Xss256k
 keytoolUtils:
   image:
     imagePullPolicy: IfNotPresent

--- a/5.5.2/fusion/charts/job-launcher/templates/deployment.yaml
+++ b/5.5.2/fusion/charts/job-launcher/templates/deployment.yaml
@@ -78,7 +78,6 @@ spec:
       - name: job-launcher
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         volumeMounts:
           - name: secrets
             mountPath: "/etc/secrets"

--- a/5.5.2/fusion/charts/job-launcher/values.yaml
+++ b/5.5.2/fusion/charts/job-launcher/values.yaml
@@ -9,10 +9,6 @@ argoNamespace: default
 config:
   springSecurity: ""
 configSources: []
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 datadog:
   enabled: false
 deploymentStrategy:

--- a/5.5.2/fusion/charts/job-rest-server/templates/deployment.yaml
+++ b/5.5.2/fusion/charts/job-rest-server/templates/deployment.yaml
@@ -63,12 +63,7 @@ spec:
       - name: job-rest-server
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          allowPrivilegeEscalation: false
-          privileged: false
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
+
         args:
           - "--spring.cloud.kubernetes.config.name={{ include "fusion.job-rest-server.fullname" . }}"
           - "--spring.profiles.active={{ include "fusion.job-rest-server.springProfs" . }}{{- if $tlsEnabled }},tls{{- end }}{{- if $jsonOutput }},logjson{{- end }}{{- if $logstashHost }},logstash{{- end }}{{- if $logPulsar }},logpulsar{{- end }}"

--- a/5.5.2/fusion/charts/job-rest-server/values.yaml
+++ b/5.5.2/fusion/charts/job-rest-server/values.yaml
@@ -2,10 +2,6 @@ accessLogEnabled: false
 affinity: {}
 config:
   springSecurity: ""
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 datadog:
   enabled: false
 deploymentStrategy:

--- a/5.5.2/fusion/charts/ml-model-service/templates/deployment.yaml
+++ b/5.5.2/fusion/charts/ml-model-service/templates/deployment.yaml
@@ -77,7 +77,6 @@ spec:
       - name: java-service
         image: "{{ .Values.javaService.repository | default .Values.image.repository }}/{{ .Values.javaService.imageName }}:{{ .Values.javaService.tag | default .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         volumeMounts:
           {{- if .Values.gcs.pretrained.enabled }}
           - name: gcs-pretrained-secret

--- a/5.5.2/fusion/charts/ml-model-service/values.yaml
+++ b/5.5.2/fusion/charts/ml-model-service/values.yaml
@@ -124,10 +124,6 @@ autoscaling:
       targetAverageUtilization: 70
     type: Resource
   minReplicas: 1
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 deploymentStrategy:
   rollingUpdate:
     maxSurge: 25%

--- a/5.5.2/fusion/charts/pm-ui/templates/deployment.yaml
+++ b/5.5.2/fusion/charts/pm-ui/templates/deployment.yaml
@@ -69,8 +69,6 @@ spec:
       - name: pm-ui
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
-
         # args:
         #   -
         ports:

--- a/5.5.2/fusion/charts/pm-ui/values.yaml
+++ b/5.5.2/fusion/charts/pm-ui/values.yaml
@@ -8,10 +8,6 @@ autoscaling:
       targetAverageUtilization: 70
     type: Resource
   minReplicas: 1
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 deploymentStrategy:
   rollingUpdate:
     maxSurge: 25%

--- a/5.5.2/fusion/charts/pulsar/templates/autorecovery-statefulset.yaml
+++ b/5.5.2/fusion/charts/pulsar/templates/autorecovery-statefulset.yaml
@@ -61,8 +61,6 @@ spec:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.autorecovery.component }}"
         image: "{{ .Values.images.autorecovery.repository }}:{{ .Values.images.autorecovery.tag }}"
         imagePullPolicy: {{ .Values.images.autorecovery.pullPolicy }}
-        securityContext:
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
       {{- if .Values.autorecovery.resources }}
         resources:
 {{ toYaml .Values.autorecovery.resources | indent 10 }}

--- a/5.5.2/fusion/charts/pulsar/templates/bookkeeper-statefulset.yaml
+++ b/5.5.2/fusion/charts/pulsar/templates/bookkeeper-statefulset.yaml
@@ -34,6 +34,9 @@ spec:
 {{- end }}
     spec:
       imagePullSecrets: {{ toYaml .Values.images.imagePullSecrets | nindent 8 }}
+{{- if $tlsEnabled }}
+      serviceAccountName: "{{ .Values.bookkeeper.serviceAccountName | default ( printf "%s-%s" (include "pulsar.fullname" .) ( .Values.bookkeeper.component )) }}"
+{{- end }}
     {{- if .Values.bookkeeper.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.bookkeeper.nodeSelector | indent 8 }}
@@ -156,8 +159,6 @@ spec:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.bookkeeper.component }}"
         image: "{{ .Values.images.bookie.repository }}:{{ .Values.images.bookie.tag }}"
         imagePullPolicy: {{ .Values.images.bookie.pullPolicy }}
-        securityContext:
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         {{- if .Values.bookkeeper.probe.liveness.enabled }}
         livenessProbe:
           httpGet:

--- a/5.5.2/fusion/charts/pulsar/templates/broker-statefulset.yaml
+++ b/5.5.2/fusion/charts/pulsar/templates/broker-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
         {{ toYaml .Values.images.imagePullSecrets | nindent 8 }}
       initContainers:
 {{- if $tlsEnabled -}}
-{{ $params := dict "Release" .Release "global" .Values.global "tls" .Values.broker.tls "tlsServiceName" (printf "%s-%s" ( include "pulsar.fullname" . ) .Values.broker.component ) "keytoolUtils" .Values.keytoolUtils "securityContext" .Values.broker.securityContext  }}
+{{ $params := dict "Release" .Release "global" .Values.global "tls" .Values.broker.tls "tlsServiceName" (printf "%s-%s" ( include "pulsar.fullname" . ) .Values.broker.component ) "keytoolUtils" .Values.keytoolUtils "securityContext" .Values.broker.securityContext }}
 {{ include "fusion.tls.init-container-v2" $params | indent 6 }}
 {{- end }}
       # This initContainer will wait for bookkeeper initnewcluster to complete
@@ -203,8 +203,6 @@ spec:
         image: "{{ .Values.images.broker.repository }}:{{ .Values.images.broker.tag }}"
         imagePullPolicy: {{ .Values.images.broker.pullPolicy }}
         {{- if .Values.broker.probe.liveness.enabled }}
-        securityContext:
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         livenessProbe:
           initialDelaySeconds: {{ .Values.broker.probe.liveness.initialDelaySeconds }}
           periodSeconds: {{ .Values.broker.probe.liveness.periodSeconds }}

--- a/5.5.2/fusion/charts/pulsar/templates/dashboard-deployment.yaml
+++ b/5.5.2/fusion/charts/pulsar/templates/dashboard-deployment.yaml
@@ -41,8 +41,6 @@ spec:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.dashboard.component }}"
         image: "{{ .Values.dashboard.image.repository }}:{{ .Values.dashboard.image.tag }}"
         imagePullPolicy: {{ .Values.dashboard.image.pullPolicy }}
-        securityContext:
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
       {{- if .Values.dashboard.resources }}
         resources:
 {{ toYaml .Values.dashboard.resources | indent 10 }}

--- a/5.5.2/fusion/charts/pulsar/templates/proxy-statefulset.yaml
+++ b/5.5.2/fusion/charts/pulsar/templates/proxy-statefulset.yaml
@@ -45,7 +45,7 @@ spec:
         {{ toYaml .Values.image.imagePullSecrets | nindent 8 }}
       initContainers:
 {{- if $tlsEnabled -}}
-{{ $params := dict "Release" .Release "global" .Values.global "tls" .Values.proxy.tls "tlsServiceName" (printf "%s-%s" ( include "pulsar.fullname" . ) .Values.proxy.component ) "keytoolUtils" .Values.keytoolUtils "securityContext" .Values.proxy.securityContext  }}
+{{ $params := dict "Release" .Release "global" .Values.global "tls" .Values.proxy.tls "tlsServiceName" (printf "%s-%s" ( include "pulsar.fullname" . ) .Values.proxy.component ) "keytoolUtils" .Values.keytoolUtils  "securityContext" .Values.proxy.securityContext }}
 {{ include "fusion.tls.init-container-v2" $params | indent 6 }}
 {{- end }}
       # This init container will wait for at least one broker to be ready before
@@ -68,8 +68,6 @@ spec:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.proxy.component }}"
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.imagePullPolicy }}
-        securityContext:
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         {{- if .Values.proxy.probe.liveness.enabled }}
         livenessProbe:
           httpGet:

--- a/5.5.2/fusion/charts/pulsar/templates/pulsar-manager-deployment.yaml
+++ b/5.5.2/fusion/charts/pulsar/templates/pulsar-manager-deployment.yaml
@@ -35,8 +35,6 @@ spec:
         - name: "{{ template "pulsar.fullname" . }}-{{ .Values.pulsar_manager.component }}"
           image: "{{ .Values.images.pulsar_manager.repository }}:{{ .Values.images.pulsar_manager.tag }}"
           imagePullPolicy: {{ .Values.images.pulsar_manager.pullPolicy }}
-          securityContext:
-{{- .Values.containersSecurityContext | toYaml | nindent 12 }}
         {{- if .Values.pulsar_manager.resources }}
           resources:
 {{ toYaml .Values.pulsar_manager.resources | indent 12 }}

--- a/5.5.2/fusion/charts/pulsar/templates/toolset-statefulset.yaml
+++ b/5.5.2/fusion/charts/pulsar/templates/toolset-statefulset.yaml
@@ -38,8 +38,6 @@ spec:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.toolset.component }}"
         image: "{{ .Values.images.broker.repository }}:{{ .Values.images.broker.tag }}"
         imagePullPolicy: {{ .Values.images.broker.pullPolicy }}
-        securityContext:
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
       {{- if .Values.toolset.resources }}
         resources:
 {{ toYaml .Values.toolset.resources | indent 10 }}

--- a/5.5.2/fusion/charts/pulsar/templates/zookeeper-statefulset.yaml
+++ b/5.5.2/fusion/charts/pulsar/templates/zookeeper-statefulset.yaml
@@ -41,8 +41,6 @@ spec:
       - name: "{{ template "pulsar.fullname" . }}-{{ .Values.zookeeper.component }}"
         image: "{{ .Values.images.zookeeper.repository }}:{{ .Values.images.zookeeper.tag }}"
         imagePullPolicy: {{ .Values.images.zookeeper.pullPolicy }}
-        securityContext:
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
       {{- if .Values.zookeeper.resources }}
         resources:
 {{ toYaml .Values.zookeeper.resources | indent 10 }}

--- a/5.5.2/fusion/charts/pulsar/values.yaml
+++ b/5.5.2/fusion/charts/pulsar/values.yaml
@@ -89,7 +89,6 @@ bookkeeper:
     requests:
       cpu: 500m
       memory: 2Gi
-
   service:
     spec:
       publishNotReadyAddresses: true
@@ -224,10 +223,6 @@ components:
   pulsar_manager: false
   toolset: false
   zookeeper: false
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 dashboard:
   annotations: {}
   component: dashboard

--- a/5.5.2/fusion/charts/query-pipeline/templates/deployment.yaml
+++ b/5.5.2/fusion/charts/query-pipeline/templates/deployment.yaml
@@ -31,7 +31,6 @@ spec:
       annotations:
         {{ toYaml .Values.pod.annotations | nindent 8 }}
     spec:
-
     {{- if .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml .Values.nodeSelector | nindent 8 }}
@@ -65,12 +64,6 @@ spec:
       - name: query-pipeline
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          allowPrivilegeEscalation: false
-          privileged: false
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         args:
           - "--spring.profiles.active={{ include "fusion.query-pipeline.springProfs" . }}{{- if $tlsEnabled }},tls{{- end }}{{- if $jsonOutput }},logjson{{- end }}{{- if $logstashHost }},logstash{{- end }}{{- if $logPulsar }},logpulsar{{- end }}"
           - "--spring.cloud.kubernetes.config.name={{ include "fusion.query-pipeline.fullname" . }}"

--- a/5.5.2/fusion/charts/query-pipeline/values.yaml
+++ b/5.5.2/fusion/charts/query-pipeline/values.yaml
@@ -9,10 +9,6 @@ autoscaling:
       targetAverageUtilization: 70
     type: Resource
   minReplicas: 1
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 datadog:
   enabled: false
   port: 8126

--- a/5.5.2/fusion/charts/question-answering/values.yaml
+++ b/5.5.2/fusion/charts/question-answering/values.yaml
@@ -1,7 +1,3 @@
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 image:
   debug: false
   imagePullPolicy: IfNotPresent

--- a/5.5.2/fusion/charts/recommender/values.yaml
+++ b/5.5.2/fusion/charts/recommender/values.yaml
@@ -1,7 +1,3 @@
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 image:
   imagePullPolicy: IfNotPresent
   imagePullSecrets: []

--- a/5.5.2/fusion/charts/rules-ui/templates/deployment.yaml
+++ b/5.5.2/fusion/charts/rules-ui/templates/deployment.yaml
@@ -26,7 +26,6 @@ spec:
         app.kubernetes.io/component: "rules-ui"
         app.kubernetes.io/part-of: "fusion"
     spec:
-
       volumes:
         - name: tmp
           emptyDir: {}
@@ -61,19 +60,13 @@ spec:
       {{ end }}
 {{- if $tlsEnabled }}
       initContainers:
-{{ $params := dict "tlsServiceName" ( include "fusion.rules-ui.serviceName" . ) "Release" $.Release "global" $.Values.global "tls" $.Values.tls  "keytoolUtils" $.Values.keytoolUtils "securityContext" $.Values.securityContext}}
+{{ $params := dict "tlsServiceName" ( include "fusion.rules-ui.serviceName" . ) "Release" $.Release "global" $.Values.global "tls" $.Values.tls  "keytoolUtils" $.Values.keytoolUtils }}
 {{ include "fusion.tls.init-container-v2" $params | indent 8 }}
 {{- end }}
       containers:
       - name: rules-ui
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          allowPrivilegeEscalation: false
-          privileged: false
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         # args:
         #   -
         ports:

--- a/5.5.2/fusion/charts/rules-ui/values.yaml
+++ b/5.5.2/fusion/charts/rules-ui/values.yaml
@@ -8,10 +8,6 @@ autoscaling:
       targetAverageUtilization: 70
     type: Resource
   minReplicas: 1
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 deploymentStrategy:
   rollingUpdate:
     maxSurge: 25%

--- a/5.5.2/fusion/charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
+++ b/5.5.2/fusion/charts/seldon-core-operator/templates/deployment_seldon-controller-manager.yaml
@@ -176,16 +176,12 @@ spec:
           requests:
             cpu: '{{ .Values.manager.cpuRequest }}'
             memory: '{{ .Values.manager.memoryRequest }}'
-        securityContext:
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
 {{- if not .Values.managerCreateResources }}
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
 {{- end }}
-      securityContext:
-        runAsUser: {{ .Values.managerUserID }}
       imagePullSecrets: {{ .Values.image.imagePullSecrets | toYaml | nindent 8 }}
       terminationGracePeriodSeconds: 10
 {{- if not .Values.managerCreateResources }}

--- a/5.5.2/fusion/charts/seldon-core-operator/templates/deployment_seldon-spartakus-volunteer.yaml
+++ b/5.5.2/fusion/charts/seldon-core-operator/templates/deployment_seldon-spartakus-volunteer.yaml
@@ -22,8 +22,6 @@ spec:
         - /bin/sh
         image: gcr.io/google_containers/spartakus-amd64:v1.1.0
         name: seldon-spartakus-volunteer
-        securityContext:
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         volumeMounts:
         - mountPath: /etc/config
           name: seldon-spartakus-config-volume

--- a/5.5.2/fusion/charts/seldon-core-operator/values.yaml
+++ b/5.5.2/fusion/charts/seldon-core-operator/values.yaml
@@ -3,10 +3,6 @@ ambassador:
   singleNamespace: true
 certManager:
   enabled: false
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 controllerId: ""
 crd:
   annotations: {}
@@ -81,7 +77,6 @@ keda:
 kubeflow: false
 manager:
   annotations: {}
-  containerSecurityContext: {}
   cpuLimit: 500m
   cpuRequest: 100m
   deploymentNameAsPrefix: false

--- a/5.5.2/fusion/charts/solr/templates/exporter-deployment.yaml
+++ b/5.5.2/fusion/charts/solr/templates/exporter-deployment.yaml
@@ -105,8 +105,6 @@ spec:
               path: "/metrics"
               port: {{ .Values.exporter.port }}
           {{- if .Values.exporter.configXml }}
-          securityContext:
-{{- .Values.containersSecurityContext | toYaml | nindent 12 }}
           volumeMounts:
             - name: exporter-config
               readOnly: true

--- a/5.5.2/fusion/charts/solr/templates/statefulset.yaml
+++ b/5.5.2/fusion/charts/solr/templates/statefulset.yaml
@@ -246,9 +246,6 @@ spec:
               scheme: "{{ $tlsEnabled | ternary "HTTPS" "HTTP" }}"
               path: /solr/admin/info/health
               port: {{ $.Values.port }}
-          securityContext:
-            capabilities:
-                drop: ["NET_RAW"]
           volumeMounts:
             - name: {{ template "solr.pvc-name" $ }}{{- if not (eq $nodePool.name "") -}}-{{- end -}}{{ $nodePool.name }}
               mountPath: /var/solr

--- a/5.5.2/fusion/charts/solr/values.yaml
+++ b/5.5.2/fusion/charts/solr/values.yaml
@@ -12,10 +12,6 @@ autoscaling:
 config:
   solrlog4j: ""
   solrxml: ""
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 exporter:
   affinity: {}
   configDir: /opt/solr/contrib/prometheus-exporter/conf
@@ -151,10 +147,6 @@ zookeeper:
   - if [ -d /data/data/version-2/ ]; then if ! ls /data/data/version-2/snapshot* >
     /dev/null 2>&1; then wget -O /data/data/version-2/snapshot.0 https://issues.apache.org/jira/secure/attachment/12928686/snapshot.0;
     fi; fi && /config-scripts/run
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   env:
     JMXAUTH: "false"
     JMXDISABLE: "false"

--- a/5.5.2/fusion/charts/sql-service/templates/deployment-catalog-manager.yaml
+++ b/5.5.2/fusion/charts/sql-service/templates/deployment-catalog-manager.yaml
@@ -48,7 +48,6 @@ spec:
 {{- end }}
 {{- include "fusion.initContainers.checkZk-v2" . | nindent 8 }}
 {{- include "fusion.initContainers.checkPulsar-v2" . | nindent 8 }}
-
 {{- if .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml .Values.nodeSelector | nindent 8 }}
@@ -75,7 +74,6 @@ spec:
       - name: sql-service
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         env:
           - name: "SQL_JVM_OPTIONS"
             value: "{{ .Values.jvmOptions }}

--- a/5.5.2/fusion/charts/sql-service/templates/deployment-catalog-reader.yaml
+++ b/5.5.2/fusion/charts/sql-service/templates/deployment-catalog-reader.yaml
@@ -47,7 +47,6 @@ spec:
 {{- end }}
 {{- include "fusion.initContainers.checkZk-v2" . | nindent 8 }}
 {{- include "fusion.initContainers.checkPulsar-v2" . | nindent 8 }}
-
     {{- if .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml .Values.nodeSelector | nindent 8 }}
@@ -74,7 +73,6 @@ spec:
       - name: sql-service
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         env:
           - name: "SQL_JVM_OPTIONS"
             value: "{{ .Values.jvmOptions }}

--- a/5.5.2/fusion/charts/sql-service/values.yaml
+++ b/5.5.2/fusion/charts/sql-service/values.yaml
@@ -1,10 +1,6 @@
 affinity: {}
 config:
   springSecurity: ""
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 deploymentStrategy:
   rollingUpdate:
     maxSurge: 25%

--- a/5.5.2/fusion/charts/templating/templates/deployment.yaml
+++ b/5.5.2/fusion/charts/templating/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
         {{ toYaml .Values.pod.annotations | nindent 8 }}
     spec:
-
+    
     {{- if .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml .Values.nodeSelector | nindent 8 }}
@@ -65,12 +65,6 @@ spec:
       - name: templating
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          allowPrivilegeEscalation: false
-          privileged: false
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         args:
           - "--spring.profiles.active={{ include "fusion.templating.springProfs" . }}{{- if $tlsEnabled }},tls{{- end }}{{- if $jsonOutput }},logjson{{- end }}{{- if $logstashHost }},logstash{{- end }}{{- if $logPulsar }},logpulsar{{- end }}"
           - "--spring.cloud.kubernetes.config.name={{ include "fusion.templating.fullname" . }}"

--- a/5.5.2/fusion/charts/templating/values.yaml
+++ b/5.5.2/fusion/charts/templating/values.yaml
@@ -9,10 +9,6 @@ autoscaling:
       targetAverageUtilization: 70
     type: Resource
   minReplicas: 1
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 datadog:
   enabled: false
   port: 8126

--- a/5.5.2/fusion/charts/tikaserver/templates/deployment.yaml
+++ b/5.5.2/fusion/charts/tikaserver/templates/deployment.yaml
@@ -105,6 +105,8 @@ spec:
           - name: tika-config
             mountPath: "/tika-config.xml"
             subPath: "tika-config.xml"
+	resouces:
+	  {{- toYaml .Values.resources | nindent 10 }}
       volumes:
         - name: tmp
           emptyDir: { }

--- a/5.5.2/fusion/charts/tikaserver/templates/deployment.yaml
+++ b/5.5.2/fusion/charts/tikaserver/templates/deployment.yaml
@@ -29,7 +29,6 @@ spec:
       annotations:
         {{ toYaml .Values.pod.annotations | nindent 8 }}
     spec:
-
     {{- if .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml .Values.nodeSelector | nindent 8 }}
@@ -56,12 +55,6 @@ spec:
       - name: tikaserver
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          allowPrivilegeEscalation: false
-          privileged: false
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         {{- if not $tlsEnabled }}
         command:
           - /bin/sh
@@ -105,8 +98,6 @@ spec:
           - name: tika-config
             mountPath: "/tika-config.xml"
             subPath: "tika-config.xml"
-	resouces:
-	  {{- toYaml .Values.resources | nindent 10 }}
       volumes:
         - name: tmp
           emptyDir: { }

--- a/5.5.2/fusion/charts/tikaserver/values.yaml
+++ b/5.5.2/fusion/charts/tikaserver/values.yaml
@@ -1,8 +1,4 @@
 affinity: {}
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 extractInlineImages: false
 fusion-common-utils:
   global: {}

--- a/5.5.2/fusion/charts/webapps/templates/deployment.yaml
+++ b/5.5.2/fusion/charts/webapps/templates/deployment.yaml
@@ -78,12 +78,6 @@ spec:
       - name: webapps
         image: "{{ .Values.image.repository }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
         imagePullPolicy: "{{ .Values.image.imagePullPolicy }}"
-        securityContext:
-          readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          allowPrivilegeEscalation: false
-          privileged: false
-{{- .Values.containersSecurityContext | toYaml | nindent 10 }}
         args:
           - "--spring.profiles.active=kubernetes,jwt,fusion{{- if $tlsEnabled }},tls{{- end }}{{- if $jsonOutput }},logjson{{- end }}{{- if $logstashHost }},logstash{{- end }}{{- if $logPulsar }},logpulsar{{- end }}"
           - "--spring.cloud.kubernetes.config.name={{ include "fusion.webapps.fullname" . }}"

--- a/5.5.2/fusion/charts/webapps/values.yaml
+++ b/5.5.2/fusion/charts/webapps/values.yaml
@@ -8,10 +8,6 @@ autoscaling:
       targetAverageUtilization: 70
     type: Resource
   minReplicas: 1
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 deploymentStrategy:
   rollingUpdate:
     maxSurge: 25%

--- a/5.5.2/fusion/charts/zookeeper/templates/statefulset.yaml
+++ b/5.5.2/fusion/charts/zookeeper/templates/statefulset.yaml
@@ -89,8 +89,6 @@ spec:
             timeoutSeconds: 5
             failureThreshold: 2
             successThreshold: 1
-          securityContext:
-{{- .Values.containersSecurityContext | toYaml | nindent 12 }}
           env:
             - name: ZK_CONF_DIR
               value: /tmp

--- a/5.5.2/fusion/charts/zookeeper/values.yaml
+++ b/5.5.2/fusion/charts/zookeeper/values.yaml
@@ -3,10 +3,6 @@ command:
 - /bin/bash
 - -xec
 - /config-scripts/run
-containersSecurityContext:
-  capabilities:
-    drop:
-    - NET_RAW
 env:
   JMXAUTH: "false"
   JMXDISABLE: "false"

--- a/5.5.2/fusion/values.yaml
+++ b/5.5.2/fusion/values.yaml
@@ -581,7 +581,7 @@ classic-rest-service:
     repository: lucidworks
     tag: 5.5.2
   javaToolOptions: -XX:+ExitOnOutOfMemoryError -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=75.0
-    -Xss256k -Dhttp.maxConnections=1000
+    -Xss256k
   keytoolUtils:
     image:
       imagePullPolicy: IfNotPresent
@@ -732,7 +732,7 @@ connector-plugin:
     repository: lucidworks
     tag: 5.5.2
   javaToolOptions: -XX:+ExitOnOutOfMemoryError -XX:MaxRAMPercentage=40.0 -Xss256k
-    -Dhttp.maxConnections=1000 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps
+    -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps
     -XX:+StartAttachListener -Djdk.attach.allowAttachSelf=true
   keytoolUtils:
     image:
@@ -841,7 +841,7 @@ connectors:
     repository: lucidworks
     tag: 5.5.2
   javaToolOptions: -XX:+ExitOnOutOfMemoryError -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=75.0
-    -Xss256k -Dhttp.maxConnections=1000
+    -Xss256k
   keytoolUtils:
     image:
       imagePullPolicy: IfNotPresent
@@ -947,7 +947,7 @@ connectors-backend:
     repository: lucidworks
     tag: 5.5.2
   javaToolOptions: -XX:+ExitOnOutOfMemoryError -XX:InitialRAMPercentage=40.0 -XX:MaxRAMPercentage=75.0
-    -Xss256k -Dhttp.maxConnections=1000 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps
+    -Xss256k -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps
     -XX:+StartAttachListener -Djdk.attach.allowAttachSelf=true
   keytoolUtils:
     image:
@@ -1145,7 +1145,7 @@ fusion-admin:
     host: ingress.example.com
     tls:
       enabled: false
-  jvmOptions: -XX:+ExitOnOutOfMemoryError -Xms1g -Xmx2g -Xss256k -Dhttp.maxConnections=1000
+  jvmOptions: -XX:+ExitOnOutOfMemoryError -Xms1g -Xmx2g -Xss256k
     -XX:PermSize=256m -XX:MaxPermSize=512m
   keytoolUtils:
     image:
@@ -1279,7 +1279,7 @@ fusion-indexing:
     name: fusion-indexing
     repository: lucidworks
     tag: 5.5.2
-  javaToolOptions: -XX:+ExitOnOutOfMemoryError -Xms512m -Xmx1g -Xss256k -Dhttp.maxConnections=1000
+  javaToolOptions: -XX:+ExitOnOutOfMemoryError -Xms512m -Xmx1g -Xss256k
   keytoolUtils:
     image:
       imagePullPolicy: IfNotPresent

--- a/5.5.2/fusion/values.yaml
+++ b/5.5.2/fusion/values.yaml
@@ -1404,7 +1404,7 @@ fusion-log-forwarder:
   podDisruptionBudget:
     maxUnavailable: 1
   processorCount: 10
-  pulsarBacklogLimit: 1073741824
+  pulsarBacklogLimit: 3073741824
   pulsarBacklogPolicy: consumer_backlog_eviction
   pulsarNamespace: _logs
   pulsarNamespaceSizeRetention: 0

--- a/5.5.2/fusion/values.yaml
+++ b/5.5.2/fusion/values.yaml
@@ -9,10 +9,6 @@ admin-ui:
         targetAverageUtilization: 70
       type: Resource
     minReplicas: 1
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   deploymentStrategy:
     rollingUpdate:
       maxSurge: 25%
@@ -92,10 +88,6 @@ api-gateway:
     resilience4j: ""
     security: ""
     springSecurity: ""
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   datadog:
     enabled: false
     port: 8126
@@ -217,10 +209,7 @@ argo:
       insecure: true
       secretKeySecret:
         key: secretkey
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
+
   controller:
     affinity: {}
     containerRuntimeExecutor: k8sapi
@@ -309,10 +298,6 @@ argo:
     certsPath: /etc/minio/certs/
     clusterDomain: cluster.local
     configPathmc: /etc/minio/mc/
-    containersSecurityContext:
-      capabilities:
-        drop:
-        - NET_RAW
     defaultBucket:
       enabled: true
       name: argo-artifacts
@@ -488,10 +473,6 @@ auth-ui:
         targetAverageUtilization: 70
       type: Resource
     minReplicas: 1
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   deploymentStrategy:
     rollingUpdate:
       maxSurge: 25%
@@ -561,10 +542,6 @@ classic-rest-service:
   annotations: {}
   bootstrapEnabled: true
   component: classic-rest-service
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   deploymentStrategy:
     rollingUpdate:
       maxSurge: 25%
@@ -821,10 +798,6 @@ connectors:
       type: Resource
     minReplicas: 1
   component: connectors
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   deploymentStrategy:
     rollingUpdate:
       maxSurge: 25%
@@ -927,10 +900,6 @@ connectors-backend:
       type: Resource
     minReplicas: 1
   component: connectors-backend
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   deploymentStrategy:
     rollingUpdate:
       maxSurge: 25%
@@ -1046,10 +1015,6 @@ devops-ui:
         targetAverageUtilization: 70
       type: Resource
     minReplicas: 1
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   deploymentStrategy:
     rollingUpdate:
       maxSurge: 25%
@@ -1124,10 +1089,6 @@ fusion-admin:
         targetAverageUtilization: 70
       type: Resource
     minReplicas: 1
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   fusion-common-utils:
     global: {}
   global: {}
@@ -1258,10 +1219,6 @@ fusion-indexing:
         targetAverageUtilization: 70
       type: Resource
     minReplicas: 1
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   datadog:
     enabled: false
     port: 8126
@@ -1536,10 +1493,6 @@ job-launcher:
   config:
     springSecurity: ""
   configSources: []
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   datadog:
     enabled: false
   deploymentStrategy:
@@ -1643,10 +1596,6 @@ job-rest-server:
   affinity: {}
   config:
     springSecurity: ""
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   datadog:
     enabled: false
   deploymentStrategy:
@@ -1860,10 +1809,6 @@ ml-model-service:
         targetAverageUtilization: 70
       type: Resource
     minReplicas: 1
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   deploymentStrategy:
     rollingUpdate:
       maxSurge: 25%
@@ -2280,10 +2225,6 @@ pm-ui:
         targetAverageUtilization: 70
       type: Resource
     minReplicas: 1
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   deploymentStrategy:
     rollingUpdate:
       maxSurge: 25%
@@ -2574,10 +2515,6 @@ pulsar:
     pulsar_manager: false
     toolset: false
     zookeeper: false
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   dashboard:
     annotations: {}
     component: dashboard
@@ -2875,10 +2812,6 @@ query-pipeline:
         targetAverageUtilization: 70
       type: Resource
     minReplicas: 1
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   datadog:
     enabled: false
     port: 8126
@@ -2978,10 +2911,6 @@ query-pipeline:
   zkReplicaCount: 3
   zkTLSPort: 2281
 question-answering:
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   global: {}
   image:
     debug: false
@@ -3042,10 +2971,6 @@ question-answering:
       sparkSolrEtl: null
       train: null
 recommender:
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   global: {}
   image:
     imagePullPolicy: IfNotPresent
@@ -3092,10 +3017,6 @@ rules-ui:
         targetAverageUtilization: 70
       type: Resource
     minReplicas: 1
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   deploymentStrategy:
     rollingUpdate:
       maxSurge: 25%
@@ -3242,7 +3163,6 @@ seldon-core-operator:
   logstashEnabled: true
   manager:
     annotations: {}
-    containerSecurityContext: {}
     cpuLimit: 500m
     cpuRequest: 100m
     deploymentNameAsPrefix: false
@@ -3334,10 +3254,6 @@ solr:
   config:
     solrlog4j: ""
     solrxml: ""
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   exporter:
     affinity: {}
     configDir: /opt/solr/contrib/prometheus-exporter/conf
@@ -3476,10 +3392,6 @@ solr:
     - if [ -d /data/data/version-2/ ]; then if ! ls /data/data/version-2/snapshot*
       > /dev/null 2>&1; then wget -O /data/data/version-2/snapshot.0 https://issues.apache.org/jira/secure/attachment/12928686/snapshot.0;
       fi; fi && /config-scripts/run
-    containersSecurityContext:
-      capabilities:
-        drop:
-        - NET_RAW
     enabled: false
     env:
       JMXAUTH: "false"
@@ -3770,10 +3682,6 @@ sql-service:
   affinity: {}
   config:
     springSecurity: ""
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   deploymentStrategy:
     rollingUpdate:
       maxSurge: 25%
@@ -3879,10 +3787,6 @@ templating:
         targetAverageUtilization: 70
       type: Resource
     minReplicas: 1
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   datadog:
     enabled: false
     port: 8126
@@ -3977,10 +3881,6 @@ templating:
   zkTLSPort: 2281
 tikaserver:
   affinity: {}
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   extractInlineImages: false
   fusion-common-utils:
     global: {}
@@ -4049,10 +3949,6 @@ webapps:
         targetAverageUtilization: 70
       type: Resource
     minReplicas: 1
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   deploymentStrategy:
     rollingUpdate:
       maxSurge: 25%
@@ -4142,10 +4038,6 @@ zookeeper:
   - if [ -d /data/data/version-2/ ]; then if ! ls /data/data/version-2/snapshot* >
     /dev/null 2>&1; then wget -O /data/data/version-2/snapshot.0 https://issues.apache.org/jira/secure/attachment/12928686/snapshot.0;
     fi; fi && /config-scripts/run
-  containersSecurityContext:
-    capabilities:
-      drop:
-      - NET_RAW
   env:
     JMXAUTH: "false"
     JMXDISABLE: "false"


### PR DESCRIPTION
Openshift updates including 

- javatooloptions updates for kubernetes connection timeouts, removal of maxconnections, and logging updates for connectors-backend, and plugins logs to be indexed into Fusion for viewing in Devops
- Removed service account references for various deployments for GIC openshift 
